### PR TITLE
add ethereum config

### DIFF
--- a/config/ethereum.json
+++ b/config/ethereum.json
@@ -1,0 +1,44 @@
+{
+    "prize_pool": {
+        "tier_liquidity_utilization_rate": "500000000000000000",
+        "draw_period_seconds": "2419200",
+        "first_draw_starts_at": "",
+        "grand_prize_period_draws": "6",
+        "number_of_tiers": "4",
+        "tier_shares": "100",
+        "canary_shares": "4",
+        "reserve_shares": "30",
+        "draw_timeout": "5",
+        "prize_token": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
+    },
+
+    "stake_to_win": {
+        "staking_vault": {
+            "asset": "0x0cEC1A9154Ff802e7934Fc916Ed7Ca50bDE6844e",
+            "name": "Staked POOL",
+            "symbol": "stPOOL"
+        },
+        "prize_vault": {
+            "name": "Prize POOL",
+            "symbol": "przPOOL"
+        }
+    },
+        
+    "rng": {
+        "contract": "0xC0FFEE98AD1434aCbDB894BbB752e138c1006fAB",
+        "type": "witnet-randomness-v2"
+    },
+
+    "draw_manager": {
+        "draw_auction_duration": "86400",
+        "draw_auction_target_sale_time": "43200",
+        "draw_auction_target_first_sale_fraction": "250000000000000000",
+        "draw_auction_max_reward": "1000000000000000000",
+        "draw_auction_max_retries": "2"
+    },
+
+    "claimer": {
+        "time_to_reach_max_fee": "86400",
+        "max_fee_percent": "100000000000000000"
+    }
+}


### PR DESCRIPTION
- 4 week draw period
- 6 month GP period
- 5 draw timeout (must be lower than GP period)
- 1 day till max claim fees
- 12 hours till target draw auction price, 1 day max per auction
- max auction reward upped to 1 ETH from 0.033 ETH on L2s
- normal share splits (100/30/4)
- normal utilization rate (50%)